### PR TITLE
Add view transitions for post titles and dates

### DIFF
--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -1,5 +1,6 @@
 ---
 import { Font } from 'astro:assets'
+import { ClientRouter } from 'astro:transitions'
 
 import '~/assets/css/app.css'
 
@@ -7,7 +8,7 @@ const { class: bodyClass } = Astro.props
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang="en" transition:name="root" transition:animate="none">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -17,6 +18,8 @@ const { class: bodyClass } = Astro.props
 
     <Font cssVariable="--font-inter" preload />
     <Font cssVariable="--font-jetbrains-mono" preload />
+
+    <ClientRouter />
 
     <slot name="meta" />
   </head>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -54,13 +54,13 @@ const {
     }
 
     <header class="mt-8 mb-10">
-      <h1 class="text-4xl font-semibold tracking-tight text-zinc-50">{post.data.title}</h1>
+      <h1 class="text-4xl font-semibold tracking-tight text-zinc-50" transition:name={`post-title-${post.id}`}>{post.data.title}</h1>
       <div class="mt-3">
         {
           !post.data.date ? (
             <span class="rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-400">Draft</span>
           ) : (
-            <time class="font-mono text-sm text-zinc-500" datetime={post.data.date!.toISO()}>
+            <time class="font-mono text-sm text-zinc-500" datetime={post.data.date!.toISO()} transition:name={`post-date-${post.id}`}>
               {post.data.date!.toFormat('yyyy-LL-dd')}
             </time>
           )

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -26,13 +26,13 @@ const websiteStructuredData = {
           class="group block rounded-2xl bg-white/[0.03] p-6 ring-1 ring-white/10 transition-colors hover:bg-white/[0.06] hover:ring-white/20"
         >
           <div class="flex items-baseline justify-between gap-4">
-            <h2 class="text-base font-medium text-zinc-50">{post.data.title}</h2>
+            <h2 class="text-base font-medium text-zinc-50" transition:name={`post-title-${post.id}`}>{post.data.title}</h2>
             {!post.data.date ? (
               <span class="shrink-0 rounded-full bg-red-500/10 px-2 py-0.5 text-xs font-medium text-red-400">
                 Draft
               </span>
             ) : (
-              <time class="shrink-0 font-mono text-sm text-zinc-500" datetime={post.data.date!.toISO()}>
+              <time class="shrink-0 font-mono text-sm text-zinc-500" datetime={post.data.date!.toISO()} transition:name={`post-date-${post.id}`}>
                 {post.data.date!.toFormat('yyyy-LL-dd')}
               </time>
             )}


### PR DESCRIPTION
## What

Adds Astro view transitions so post **titles and dates** morph smoothly from the blog index card into the post header on navigation. Only those two elements animate — the rest of the page has no transition.

## How

- `<ClientRouter />` (`astro:transitions`) in `Main.astro` — enables client-side navigation + the View Transitions API.
- `transition:animate="none"` on `<html>` — disables Astro's default full-page crossfade so only named elements animate.
- `transition:name={\`post-title-${post.id}\`}` / `post-date-${post.id}` shared between the index card and the post page so they morph into the post header.

## Verified (dev server)

- Clicking a card fires a real `startViewTransition` and navigates client-side to the post.
- Code-copy button still works after SPA navigation (scripts re-run correctly under `ClientRouter`).

Cloudflare preview should build from this branch for visual review. Merge to `main` deploys to production.
